### PR TITLE
remove usage of typeid

### DIFF
--- a/putils/reflection.hpp
+++ b/putils/reflection.hpp
@@ -54,7 +54,7 @@ namespace putils::reflection {
 	consteval bool is_reflectible() noexcept;
 
 	template<typename T>
-	consteval auto get_class_name() noexcept;
+	constexpr auto get_class_name() noexcept;
 
 	template<typename T>
 	consteval const auto & get_parents() noexcept;

--- a/putils/tests/reflection.tests.cpp
+++ b/putils/tests/reflection.tests.cpp
@@ -84,7 +84,7 @@ TEST(reflection, is_reflectible_false) {
 
 struct barebones_reflectible {};
 #define refltype barebones_reflectible
-putils_reflection_info {};
+putils_reflection_info{};
 #undef refltype
 
 TEST(reflection, is_reflectible_barebones) {


### PR DESCRIPTION
+ make get_class_name constexpr instead of consteval (fixes weird msvc crash)